### PR TITLE
Use node-alpine and multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
-FROM node:10
+FROM    node:10-alpine as build
 WORKDIR /usr/src/app
-COPY package*.json ./
-RUN npm install
-COPY . .
+COPY    . .
+RUN     npm install
+RUN     npm run build
 
-EXPOSE 3000
 
-CMD [ "npm", "start" ]
+FROM    node:10-alpine
+WORKDIR /usr/src/app
+COPY    --from=build /usr/src/app ./
+
+EXPOSE  3000
+
+CMD     [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ $ npm start
 ### Dockerize
 
 #### Build docker image
-<strong><em>* You must build .js bundles($ npm run build) before build a docker image</em></strong>
+Enable [Docker Buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds) to speed up build
 ```bsh
-$ docker build -t <dockerhub_username>/<dockerhub_repo_name>:latest .
+$ DOCKER_BUILDKIT=1 docker build -t <dockerhub_username>/<dockerhub_repo_name>:latest .
 ```
 
 #### Run


### PR DESCRIPTION
This should avoid having to run `npm` commands before you can actually build the image and also reduce image size by a lot
```
REPOSITORY                                               TAG                            IMAGE ID            CREATED             SIZE
phuongdh/corona                                          new                            f39293c52673        7 minutes ago       522MB
phuongdh/corona                                          old                            4c2816ec2304        14 minutes ago      1.43GB
```